### PR TITLE
PORT-4010 BLEM: Preheader Text field in CMS (Marketo)

### DIFF
--- a/src/Endpoint/Asset/Email.php
+++ b/src/Endpoint/Asset/Email.php
@@ -187,22 +187,26 @@ class Email implements EndpointInterface
     }
 
     /**
-     * Update Email's name and/or description.
+     * Update fields of an Email asset.
      *
-     * @param int $id
-     * @param array{name?: string, description?: string} $fields
-     * @return Entity
+     * @param int $id Email asset ID.
+     * @param array<string, mixed> $fields Fields to update (e.g., name, description, preHeader).
+     *
+     * @return Entity Updated Email entity.
      *
      * @throws Exception
      * @throws InvalidArgumentException
+     *
+     * @see https://developer.adobe.com/marketo-apis/api/asset/#operation/updateEmailUsingPOST
      */
     public function update(int $id, array $fields = []): Entity
     {
-        $params = [];
-        $this->addFieldsToQuery($params, ['name', 'description'], $fields);
-        if (empty($params)) {
-            throw new InvalidArgumentException('Missing name and/or description.');
+        if (empty($fields)) {
+            throw new InvalidArgumentException('Missing fields for update.');
         }
+
+        $params = [];
+        $this->addFieldsToQuery($params, array_keys($fields), $fields);
 
         $response = $this->post("/email/$id.json", ['form_params' => $params]);
         $response->checkIsSuccess();


### PR DESCRIPTION
### What does this PR do? How does it affect something?
Changes the logic of the update method that interacts with the Marketo API. Makes the method more flexible by allowing dynamic fields.

### YT issue and other related links

[PORT-4010](https://cra.myjetbrains.com/youtrack/issue/PORT-4010) BLEM: Preheader Text field in CMS (Marketo)